### PR TITLE
Update Benchmark.pm6

### DIFF
--- a/lib/Benchmark.pm6
+++ b/lib/Benchmark.pm6
@@ -77,5 +77,5 @@ class Benchmark {
   }
 };
 
-sub mytime { return now; }
+
 


### PR DESCRIPTION
'now' is shorter than 'mytime'
