### PR TITLE
Do not depend on module ""

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -4,7 +4,7 @@
   "version" : "0.2.0",
   "auth" : "github:tony-o",
   "description" : "Perl6's premier benchmarking utility",
-  "depends" : [""],
+  "depends" : [ ],
   "provides" : {
       "Bench": "lib/Bench.pm6"
   },


### PR DESCRIPTION
Hello!

Currently the META6.json file has this:
```
   "depends" : [""],
```

I don't think you meant to depend on [my module](https://github.com/AlexDaniel/foo-emptystring) (I don't know if tooling even supports it). I recommend removing the dependency.